### PR TITLE
Fix driver for Suumo Movestick Mini

### DIFF
--- a/demos/ant.core/04-processevents.py
+++ b/demos/ant.core/04-processevents.py
@@ -24,7 +24,7 @@ class HRMListener(event.EventCallback):
             print 'Heart Rate:', ord(msg.payload[-1])
 
 # Initialize
-stick = driver.USB1Driver(SERIAL, log=LOG, debug=DEBUG)
+stick = driver.USB2Driver(SERIAL, log=LOG, debug=DEBUG)
 antnode = node.Node(stick)
 antnode.start()
 

--- a/src/ant/core/driver.py
+++ b/src/ant/core/driver.py
@@ -30,6 +30,7 @@ import serial
 # USB2 driver uses direct USB connection. Requires PyUSB
 import usb.core
 import usb.util
+import usb.control
 
 from ant.core.exceptions import DriverError
 

--- a/src/ant/core/driver.py
+++ b/src/ant/core/driver.py
@@ -195,7 +195,7 @@ class USB2Driver(Driver):
         alternate_setting = usb.control.get_interface(dev, interface_number)
         intf = usb.util.find_descriptor(
             cfg, bInterfaceNumber = interface_number,
-            AlternateSetting = alternate_setting
+            bAlternateSetting = alternate_setting
         )
         usb.util.claim_interface(dev, interface_number)
         ep_out = usb.util.find_descriptor(

--- a/src/ant/core/event.py
+++ b/src/ant/core/event.py
@@ -41,7 +41,7 @@ from ant.core.exceptions import MessageError
 
 def ProcessBuffer(buffer_):
     messages = []
-
+    
     while True:
         hf = Message()
         try:
@@ -63,8 +63,9 @@ def EventPump(evm):
     evm.pump_lock.release()
 
     go = True
-    buffer_ = ''
+    
     while go:
+        buffer_ = ''
         evm.running_lock.acquire()
         if not evm.running:
             go = False


### PR DESCRIPTION
Patch that fixes the USB2 Driver for the Movestick Mini.
