### PR TITLE
docs: fix simple typo, scarse -> scarce

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can reach me via e-Mail and Google Talk/Jabber at:
 
 Documentation
 -------------
-Documentation will be a bit scarse for the time being, but everything public
+Documentation will be a bit scarce for the time being, but everything public
 should have at least a docstring by the time I make the first stable release.
 
 


### PR DESCRIPTION
There is a small typo in README.md.

Should read `scarce` rather than `scarse`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md